### PR TITLE
Disable variable escaping in generated .htaccess

### DIFF
--- a/Resources/Private/Templates/Htaccess.html
+++ b/Resources/Private/Templates/Htaccess.html
@@ -1,3 +1,4 @@
+{escaping off}
 <f:if condition="{sendCacheControlHeader}">
 <IfModule mod_expires.c>
 	ExpiresActive on


### PR DESCRIPTION
All variable output in the generated .htaccess is no longer being escaped to prevent breaking some HTTP headers.